### PR TITLE
Fixes path match for style files

### DIFF
--- a/lib/channels/styles/base.js
+++ b/lib/channels/styles/base.js
@@ -12,8 +12,8 @@ var rename = require('gulp-rename');
 
 module.exports = function() {
   return combine(
-    gulpif('**/*.less', less()),
-    gulpif('**/*.{sass,scss}', sass()),
+    gulpif(/\.less$/, less()),
+    gulpif(/\.(?:sass)|(?:scss)$/, sass()),
     rename(function(path) { path.extname = '.css'; }),
     autoprefixer('last 1 version')
   );


### PR DESCRIPTION
For some reason the glob syntax was not working for me.  By changing the
match condition to a regex that matches on the file extension it seems
to now compile the css files.
